### PR TITLE
Compile error with new ubuntu gcc

### DIFF
--- a/include/marray/marray.hxx
+++ b/include/marray/marray.hxx
@@ -547,7 +547,7 @@ public:
     // STL random access iterator typedefs
     typedef typename std::random_access_iterator_tag iterator_category;
     typedef T value_type;
-    typedef ptrdiff_t difference_type;
+    typedef std::ptrdiff_t difference_type;
     typedef typename marray_detail::IfBool<isConst, const T*, T*>::type pointer;
     typedef typename marray_detail::IfBool<isConst, const T&, T&>::type reference;
 


### PR DESCRIPTION
Hi Bjoern,

I added the proper namespace prefix to ptrdiff_t to make it compile with the new ubuntu gcc.
