### PR TITLE
include cstddef for ptrdiff_t

### DIFF
--- a/include/andres/marray.hxx
+++ b/include/andres/marray.hxx
@@ -78,6 +78,7 @@
 #include <memory> // allocator
 #include <numeric> // accumulate
 #include <functional> // std::multiplies
+#include <cstddef> // ptrdiff_t
 #ifdef HAVE_CPP11_INITIALIZER_LISTS
     #include <initializer_list>
 #endif


### PR DESCRIPTION
It doesn't compile without cstddef on debian wheezy and gcc 4.7.
