### PR TITLE
use std::fill

### DIFF
--- a/include/andres/marray.hxx
+++ b/include/andres/marray.hxx
@@ -3541,9 +3541,7 @@ Marray<T, A>::Marray
     marray_detail::Assert(MARRAY_NO_ARG_TEST || size != 0);
     base::assign(shape.begin(), shape.end(), dataAllocator_.allocate(size), 
                  coordinateOrder, coordinateOrder, allocator); 
-    for(size_t j=0; j<size; ++j) {
-        this->data_[j] = value;
-    }
+    std::fill(this->data_, this->data_+size, value);
     testInvariant();
 }
 #endif


### PR DESCRIPTION
For a cwx benchmark (100^3 supervoxel segmentation), this reduces
the runtime before/after:

./cwx seg-100.h5 seg  104,92s user 0,36s system 99% cpu
./cwx seg-100.h5 seg  15,10s user 0,06s system 99% cpu
